### PR TITLE
De-duplicate file dependencies prior to attempting to copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = class WebpackCopyModulesPlugin {
     const me = this,
           fileDependencies = new Set();
 
-    compilation.modules.forEach(module => (module.buildInfo.fileDependencies ||[]).forEach(fileDependencies.add.bind(fileDependencies) ));
+    compilation.modules.forEach(module => (module.buildInfo.fileDependencies ||[])
+	    .forEach(fileDependencies.add.bind(fileDependencies) ));
 
     return Promise.all([...fileDependencies].map(function(file) {
       const relativePath = replaceParentDirReferences(path.relative('', file)),

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = class WebpackCopyModulesPlugin {
           fileDependencies = new Set();
 
     compilation.modules.forEach(module => (module.buildInfo.fileDependencies ||[])
-	    .forEach(fileDependencies.add.bind(fileDependencies) ));
+	    .forEach(fileDependencies.add.bind(fileDependencies)));
 
     return Promise.all([...fileDependencies].map(function(file) {
       const relativePath = replaceParentDirReferences(path.relative('', file)),

--- a/index.js
+++ b/index.js
@@ -36,12 +36,10 @@ module.exports = class WebpackCopyModulesPlugin {
   }
 
   handleEmit(compilation) {
-    return Promise.all(compilation.modules.map(this.saveModule.bind(this)));
-  }
-
-  saveModule(module) {
     const me = this,
-        fileDependencies = module.buildInfo.fileDependencies || new Set();
+          fileDependencies = new Set();
+
+    compilation.modules.forEach(module => (module.buildInfo.fileDependencies ||[]).forEach(fileDependencies.add.bind(fileDependencies) ));
 
     return Promise.all([...fileDependencies].map(function(file) {
       const relativePath = replaceParentDirReferences(path.relative('', file)),

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ module.exports = class WebpackCopyModulesPlugin {
 
   handleEmit(compilation) {
     const me = this,
-          fileDependencies = new Set();
+        fileDependencies = new Set();
 
     compilation.modules.forEach(module => (module.buildInfo.fileDependencies ||[])
-	    .forEach(fileDependencies.add.bind(fileDependencies)));
+        .forEach(fileDependencies.add.bind(fileDependencies)));
 
     return Promise.all([...fileDependencies].map(function(file) {
       const relativePath = replaceParentDirReferences(path.relative('', file)),


### PR DESCRIPTION
On Windows when the list of dependencies across modules contains duplicates errors can occur copying files. This uses a set to de-duplicate the files before copying.