### PR TITLE
Add support for package.json copying (1.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,18 @@ module.exports = {
 
 ### Configuration
 
-`copy-modules-webpack-plugin` currently supports a single configuration option:
+`copy-modules-webpack-plugin` currently supports the following configuration options:
 
 <dl>
   <dt>destination</dt>
   <dd>
     The destination directory where the modules will be copied.
+  </dd>
+  <dt>includePackageJsons</dt>
+  <dd>
+    Set this to true to also copy the package.json file associated with each copied module file. This may
+    be useful if you are analyzing the output with a tool that has need for additional metadata about each
+    module (Default: false)
   </dd>
 </dl>
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = class WebpackCopyModulesPlugin {
     const packageJsons = this.includePackageJsons ? this.findPackageJsonPaths(fileDependencies) : [];
 
     return Promise.all([...fileDependencies, ...packageJsons].map(function(file) {
-      const relativePath = replaceParentDirReferences(path.relative('', file)),
+      const relativePath = replaceParentDirReferences(path.relative(process.cwd(), file)),
           destPath = path.join(me.destination, relativePath),
           destDir = path.dirname(destPath);
 

--- a/tests/node_modules/outside-cwd-pkg/package.json
+++ b/tests/node_modules/outside-cwd-pkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "outside-cwd-pkg", "version": "1.0.0" }

--- a/tests/test_project/CopyModulesWebpackPlugin.test.js
+++ b/tests/test_project/CopyModulesWebpackPlugin.test.js
@@ -111,7 +111,7 @@ describe('copy-modules-webpack-plugin', function() {
       }
   );
 
-  it('does not copy package.json files when includePackageJsons is true', function(done) {
+  it('does not copy package.json files when includePackageJsons is false', function(done) {
     const pathsThatShouldBeCopied = [
           'mock_src/b.js',
           'mock_src/e.js',

--- a/tests/test_project/CopyModulesWebpackPlugin.test.js
+++ b/tests/test_project/CopyModulesWebpackPlugin.test.js
@@ -42,8 +42,6 @@ describe('copy-modules-webpack-plugin', function() {
   function testPluginConfig(pluginConfig, pathsThatShouldBeCopied, done, webpackContext) {
     const pluginDestination = path.join(outputDir.name, 'copied_modules'),
         webpackConfig = {
-          // disable things like the terser plugin that complicate test setup
-          mode: 'development',
           context: webpackContext || path.resolve(__dirname, 'mock_src'),
           entry: './b.js',
           output: {

--- a/tests/test_project/node_modules/bar-pkg/package.json
+++ b/tests/test_project/node_modules/bar-pkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "bar", "version": "1.0.0" }

--- a/tests/test_project/node_modules/baz-pkg/package.json
+++ b/tests/test_project/node_modules/baz-pkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "baz", "version": "1.0.0" }

--- a/tests/test_project/node_modules/foo-pkg/package.json
+++ b/tests/test_project/node_modules/foo-pkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "foo", "version": "1.0.0" }

--- a/tests/test_project/package.json
+++ b/tests/test_project/package.json
@@ -1,0 +1,1 @@
+{ "name": "test", "version": "1.0.0" }


### PR DESCRIPTION
In scenarios with some analysis tools, it may be useful to copy the package.json file in addition to the actual bundled code files for each dependency. This PR enables that via a new option: includePackageJsons. This option is false by default.

** This is the equivalent of #10 but for the 1.x branch of the plugin **