### PR TITLE
Webpack 5 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,14 @@ module.exports = {
   </dd>
   <dt>includePackageJsons</dt>
   <dd>
-    Set this to true to also copy the package.json file associated with each copied module file. This may
-    be useful if you are analyzing the output with a tool that has need for additional metadata about each
-    module (Default: false)
+    <p>
+      When using Webpack 4, set this to true to also copy the package.json file associated with each copied module
+      file. This may be useful if you are analyzing the output with a tool that has need for additional metadata about
+      each module (Default: false).
+    </p>
+    <p>
+      Note: when using webpack 5, the package.json files are copied regardless of the value of this flag.
+    </p>
   </dd>
 </dl>
 

--- a/index.js
+++ b/index.js
@@ -33,12 +33,16 @@ module.exports = class WebpackCopyModulesPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.emit.tapPromise('WebpackCopyModulesPlugin', this.handleEmit.bind(this));
+    // NOTE: this is only available in webpack 5+, but that's the only version we want to check for anyway
+    const webpackVersion = compiler.webpack && compiler.webpack.version;
+
+    compiler.hooks.emit.tapPromise('WebpackCopyModulesPlugin', this.handleEmit.bind(this, webpackVersion));
   }
 
-  async handleEmit(compilation) {
+  async handleEmit(webpackVersion, compilation) {
     const me = this,
-        fileDependencies = new Set();
+        fileDependencies = new Set(),
+        isWebpack5Plus = !!webpackVersion && webpackVersion.match(/^(\d+)\./)[1] >= 5;
 
     // add all fileDependencies that are actual files (parent directories are included in
     // compilation.fileDependencies)
@@ -48,7 +52,9 @@ module.exports = class WebpackCopyModulesPlugin {
       }
     }
 
-    const packageJsons = this.includePackageJsons ? this.findPackageJsonPaths(fileDependencies) : [];
+    // Webpack 5 already includes the package.json files, so no need for this step there
+    const packageJsons = !isWebpack5Plus && this.includePackageJsons ?
+        this.findPackageJsonPaths(fileDependencies) : [];
 
     return Promise.all([...fileDependencies, ...packageJsons].map(function(file) {
       const relativePath = replaceParentDirReferences(path.relative(process.cwd(), file)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,6 +706,32 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/eslint": {
+      "version": "7.2.6",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/eslint/-/eslint-7.2.6.tgz",
+      "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/eslint-scope": {
+      "version": "3.7.0",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
+      "integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.45",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/estree/-/estree-0.0.45.tgz",
+      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -730,6 +756,18 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.13",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/node/-/node-14.14.13.tgz",
+      "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1483,6 +1521,19 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.16.0",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/browserslist/-/browserslist-4.16.0.tgz",
+      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001165",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.621",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.67"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1579,6 +1630,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001166",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/caniuse-lite/-/caniuse-lite-1.0.30001166.tgz",
+      "integrity": "sha512-nCL4LzYK7F4mL0TjEMeYavafOGnBa98vTudH5c8lW9izUjnB99InG6pmC1ElAI1p0GlyZajv4ltUdFXvOHIl1A==",
       "dev": true
     },
     "capture-exit": {
@@ -1726,6 +1783,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
     "combined-stream": {
@@ -2091,6 +2154,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.625",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/electron-to-chromium/-/electron-to-chromium-1.3.625.tgz",
+      "integrity": "sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag==",
+      "dev": true
+    },
     "elliptic": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
@@ -2188,6 +2257,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3248,6 +3323,12 @@
           }
         }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "globals": {
       "version": "11.12.0",
@@ -5069,6 +5150,12 @@
         }
       }
     },
+    "node-releases": {
+      "version": "1.1.67",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/node-releases/-/node-releases-1.1.67.tgz",
+      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+      "dev": true
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6885,6 +6972,479 @@
         }
       }
     },
+    "webpack5": {
+      "version": "npm:webpack@5.10.1",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/webpack/-/webpack-5.10.1.tgz",
+      "integrity": "sha512-mHu4iM2mW7d/8R91VPPNtUCNd1D8k51TTb4e0XjylapIR6WEmW8XUTBZq8TqmShj9XYxVXJn6AzKlWnrlty6DA==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-scope": "^3.7.0",
+        "@types/estree": "^0.0.45",
+        "@webassemblyjs/ast": "1.9.1",
+        "@webassemblyjs/helper-module-context": "1.9.1",
+        "@webassemblyjs/wasm-edit": "1.9.1",
+        "@webassemblyjs/wasm-parser": "1.9.1",
+        "acorn": "^8.0.4",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.3.1",
+        "eslint-scope": "^5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.4",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.1.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "pkg-dir": "^5.0.0",
+        "schema-utils": "^3.0.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.0.3",
+        "watchpack": "^2.0.0",
+        "webpack-sources": "^2.1.1"
+      },
+      "dependencies": {
+        "@webassemblyjs/ast": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/ast/-/ast-1.9.1.tgz",
+          "integrity": "sha512-uMu1nCWn2Wxyy126LlGqRVlhdTOsO/bsBRI4dNq3+6SiSuRKRQX6ejjKgh82LoGAPSq72lDUiQ4FWVaf0PecYw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/wast-parser": "1.9.1"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.1.tgz",
+          "integrity": "sha512-5VEKu024RySmLKTTBl9q1eO/2K5jk9ZS+2HXDBLA9s9p5IjkaXxWiDb/+b7wSQp6FRdLaH1IVGIfOex58Na2pg==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.1.tgz",
+          "integrity": "sha512-y1lGmfm38djrScwpeL37rRR9f1D6sM8RhMpvM7CYLzOlHVboouZokXK/G88BpzW0NQBSvCCOnW5BFhten4FPfA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.1.tgz",
+          "integrity": "sha512-uS6VSgieHbk/m4GSkMU5cqe/5TekdCzQso4revCIEQ3vpGZgqSSExi4jWpTWwDpAHOIAb1Jfrs0gUB9AA4n71w==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.1.tgz",
+          "integrity": "sha512-ZQ2ZT6Evk4DPIfD+92AraGYaFIqGm4U20e7FpXwl7WUo2Pn1mZ1v8VGH8i+Y++IQpxPbQo/UyG0Khs7eInskzA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.9.1"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.1.tgz",
+          "integrity": "sha512-J32HGpveEqqcKFS0YbgicB0zAlpfIxJa5MjxDxhu3i5ltPcVfY5EPvKQ1suRguFPehxiUs+/hfkwPEXom/l0lw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.1.tgz",
+          "integrity": "sha512-IEH2cMmEQKt7fqelLWB5e/cMdZXf2rST1JIrzWmf4XBt3QTxGdnnLvV4DYoN8pJjOx0VYXsWg+yF16MmJtolZg==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1"
+          }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.1.tgz",
+          "integrity": "sha512-i2rGTBqFUcSXxyjt2K4vm/3kkHwyzG6o427iCjcIKjOqpWH8SEem+xe82jUk1iydJO250/CvE5o7hzNAMZf0dQ==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.1.tgz",
+          "integrity": "sha512-FetqzjtXZr2d57IECK+aId3D0IcGweeM0CbAnJHkYJkcRTHP+YcMb7Wmc0j21h5UWBpwYGb9dSkK/93SRCTrGg==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/ieee754/-/ieee754-1.9.1.tgz",
+          "integrity": "sha512-EvTG9M78zP1MmkBpUjGQHZc26DzPGZSLIPxYHCjQsBMo60Qy2W34qf8z0exRDtxBbRIoiKa5dFyWer/7r1aaSQ==",
+          "dev": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/leb128/-/leb128-1.9.1.tgz",
+          "integrity": "sha512-Oc04ub0vFfLnF+2/+ki3AE+anmW4sv9uNBqb+79fgTaPv6xJsOT0dhphNfL3FrME84CbX/D1T9XT8tjFo0IIiw==",
+          "dev": true,
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/utf8/-/utf8-1.9.1.tgz",
+          "integrity": "sha512-llkYtppagjCodFjo0alWOUhAkfOiQPQDIc5oA6C9sFAXz7vC9QhZf/f8ijQIX+A9ToM3c9Pq85X0EX7nx9gVhg==",
+          "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.1.tgz",
+          "integrity": "sha512-S2IaD6+x9B2Xi8BCT0eGsrXXd8UxAh2LVJpg1ZMtHXnrDcsTtIX2bDjHi40Hio6Lc62dWHmKdvksI+MClCYbbw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/helper-wasm-section": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1",
+            "@webassemblyjs/wasm-opt": "1.9.1",
+            "@webassemblyjs/wasm-parser": "1.9.1",
+            "@webassemblyjs/wast-printer": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.1.tgz",
+          "integrity": "sha512-bqWI0S4lBQsEN5FTZ35vYzfKUJvtjNnBobB1agCALH30xNk1LToZ7Z8eiaR/Z5iVECTlBndoRQV3F6mbEqE/fg==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/ieee754": "1.9.1",
+            "@webassemblyjs/leb128": "1.9.1",
+            "@webassemblyjs/utf8": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.1.tgz",
+          "integrity": "sha512-gSf7I7YWVXZ5c6XqTEqkZjVs8K1kc1k57vsB6KBQscSagDNbAdxt6MwuJoMjsE1yWY1tsuL+pga268A6u+Fdkg==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-buffer": "1.9.1",
+            "@webassemblyjs/wasm-gen": "1.9.1",
+            "@webassemblyjs/wasm-parser": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.1.tgz",
+          "integrity": "sha512-ImM4N2T1MEIond0MyE3rXvStVxEmivQrDKf/ggfh5pP6EHu3lL/YTAoSrR7shrbKNPpeKpGesW1LIK/L4kqduw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/helper-api-error": "1.9.1",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
+            "@webassemblyjs/ieee754": "1.9.1",
+            "@webassemblyjs/leb128": "1.9.1",
+            "@webassemblyjs/utf8": "1.9.1"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wast-parser/-/wast-parser-1.9.1.tgz",
+          "integrity": "sha512-2xVxejXSvj3ls/o2TR/zI6p28qsGupjHhnHL6URULQRcXmryn3w7G83jQMcT7PHqUfyle65fZtWLukfdLdE7qw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/floating-point-hex-parser": "1.9.1",
+            "@webassemblyjs/helper-api-error": "1.9.1",
+            "@webassemblyjs/helper-code-frame": "1.9.1",
+            "@webassemblyjs/helper-fsm": "1.9.1",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.9.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/@webassemblyjs/wast-printer/-/wast-printer-1.9.1.tgz",
+          "integrity": "sha512-tDV8V15wm7mmbAH6XvQRU1X+oPGmeOzYsd6h7hlRLz6QpV4Ec/KKxM8OpLtFmQPLCreGxTp+HuxtH4pRIZyL9w==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.1",
+            "@webassemblyjs/wast-parser": "1.9.1",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "acorn": {
+          "version": "8.0.4",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/acorn/-/acorn-8.0.4.tgz",
+          "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "5.4.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz",
+          "integrity": "sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://repo.sonatype.com/repository/npm-all/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        },
+        "events": {
+          "version": "3.2.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/events/-/events-3.2.0.tgz",
+          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "26.6.2",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/jest-worker/-/jest-worker-26.6.2.tgz",
+          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "loader-runner": {
+          "version": "4.1.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/loader-runner/-/loader-runner-4.1.0.tgz",
+          "integrity": "sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "neo-async": {
+          "version": "2.6.2",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/neo-async/-/neo-async-2.6.2.tgz",
+          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "5.0.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+          "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "tapable": {
+          "version": "2.2.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/tapable/-/tapable-2.2.0.tgz",
+          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+          "dev": true
+        },
+        "terser": {
+          "version": "5.5.1",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/terser/-/terser-5.5.1.tgz",
+          "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.19"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://repo.sonatype.com/repository/npm-all/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+              "dev": true
+            }
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "5.0.3",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
+          "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
+          "dev": true,
+          "requires": {
+            "jest-worker": "^26.6.1",
+            "p-limit": "^3.0.2",
+            "schema-utils": "^3.0.0",
+            "serialize-javascript": "^5.0.1",
+            "source-map": "^0.6.1",
+            "terser": "^5.3.8"
+          }
+        },
+        "watchpack": {
+          "version": "2.1.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/watchpack/-/watchpack-2.1.0.tgz",
+          "integrity": "sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==",
+          "dev": true,
+          "requires": {
+            "glob-to-regexp": "^0.4.1",
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "webpack-sources": {
+          "version": "2.2.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/webpack-sources/-/webpack-sources-2.2.0.tgz",
+          "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
+        }
+      }
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -7070,6 +7630,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jest": "25.1.0",
     "node-dir": "=0.1.17",
     "tmp": "0.1.0",
-    "webpack": "=4.41.5"
+    "webpack": "=4.41.5",
+    "webpack5": "npm:webpack@^5.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "node-dir": "=0.1.17",
     "tmp": "0.1.0",
     "webpack": "=4.41.5",
-    "webpack5": "npm:webpack@^5.10.1"
+    "webpack5": "npm:webpack@=5.10.1"
   }
 }


### PR DESCRIPTION
Add support for Webpack 5

This pull request makes the following changes:
* Switches to the simpler `compilation.fileDependencies` property rather than `module.fileDependencies` which doesn't appear to exist in webpack 5.
* Adds a dependency on webpack 5 in addition to the one for webpack 4
* Tests in both versions
* Doc update around the behavior of `includePackageJsons` in webpack 5

Note that webpack 5 includes the relevant package.json files in its `fileDependencies` list automatically, avoiding the need for us to calculate it ourselves (and removing the value of the `includePackageJsons` flag.

It relates to the following issue #s:
* Fixes #20 
