### PR TITLE
Check for non-existent fileDependencies to fix angular AOT

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ module.exports = class WebpackCopyModulesPlugin {
     // add all fileDependencies that are actual files (parent directories are included in
     // compilation.fileDependencies)
     for (const fileDep of compilation.fileDependencies) {
-      if ((await fs.lstat(fileDep)).isFile()) {
+      const exists = await fs.pathExists(fileDep),
+          isFile = exists && (await fs.lstat(fileDep)).isFile();
+
+      if (isFile) {
         fileDependencies.add(fileDep);
       }
     }


### PR DESCRIPTION
It appears that builds which use angular AOT compilation add additional non-existent file paths to the `fileDependencies` collection, while still also including all real file paths.  This PR simply adds a check that the file exists before calling `lstat` on it in order to avoid an error.